### PR TITLE
Benchmark multiple configurations in single JVM [#97]

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,37 +26,20 @@ services:
       - 15672:15672
 
   # TODO Make it optional
-  benchmark_resin_mongodb:
+  benchmark_resin:
     build: { context: "./hexagon_benchmark", dockerfile: "resin.dockerfile" }
-    depends_on: [ mongodb ]
-    environment: [ "DBHOST=mongodb", "DBSTORE=mongodb" ]
-    links: [ "mongodb:mongodb" ]
+    depends_on: [ mongodb, postgresql ]
+    environment: [ "MONGODB_DB_HOST=mongodb", "POSTGRESQL_DB_HOST=postgresql" ]
     ports: [ "9010:8080" ]
 
-  benchmark_jetty_mongodb:
+  benchmark_jetty:
     build: { context: "./hexagon_benchmark", dockerfile: "java.dockerfile" }
-    depends_on: [ mongodb ]
-    environment: [ "DBHOST=mongodb", "DBSTORE=mongodb" ]
-    links: [ "mongodb:mongodb" ]
+    depends_on: [ mongodb, postgresql ]
+    environment: [ "MONGODB_DB_HOST=mongodb", "POSTGRESQL_DB_HOST=postgresql" ]
     ports: [ "9020:9090" ]
 
-  benchmark_jetty_postgresql:
+  benchmark_undertow:
     build: { context: "./hexagon_benchmark", dockerfile: "java.dockerfile" }
-    depends_on: [ postgresql ]
-    environment: [ "DBHOST=postgresql", "DBSTORE=postgresql" ]
-    links: [ "postgresql:postgresql" ]
-    ports: [ "9030:9090" ]
-
-  benchmark_undertow_mongodb:
-    build: { context: "./hexagon_benchmark", dockerfile: "java.dockerfile" }
-    depends_on: [ mongodb ]
-    environment: [ "DBHOST=mongodb", "WEBENGINE=undertow", "DBSTORE=mongodb" ]
-    links: [ "mongodb:mongodb" ]
+    depends_on: [ mongodb, postgresql ]
+    environment: [ "MONGODB_DB_HOST=mongodb", "POSTGRESQL_DB_HOST=postgresql", "WEBENGINE=undertow" ]
     ports: [ "9040:9090" ]
-
-  benchmark_undertow_postgresql:
-    build: { context: "./hexagon_benchmark", dockerfile: "java.dockerfile" }
-    depends_on: [ postgresql ]
-    environment: [ "DBHOST=postgresql", "WEBENGINE=undertow", "DBSTORE=postgresql" ]
-    links: [ "postgresql:postgresql" ]
-    ports: [ "9050:9090" ]

--- a/hexagon_benchmark/build.gradle
+++ b/hexagon_benchmark/build.gradle
@@ -124,16 +124,17 @@ task benchmarkConfig() {
         tests.forEach {
             String server = it[0]
             String database = it[1]
-            String databaseCode = database == 'PostgreSQL'? 'postgres' : database.toLowerCase ()
+            String databaseEngine = database.toLowerCase()
+            String databaseCode = database == 'PostgreSQL'? 'postgres' : databaseEngine
             String name = server == servers.first () && database == databases.first ()?
                 'default' : server + '_' + database
             int port = server == 'Resin'? 8080 : 9090
             test[name.toLowerCase()] = [
                 json_url : '/json',
-                db_url : '/db',
-                query_url : '/query?queries=',
-                fortune_url : '/fortunes',
-                update_url : '/update?queries=',
+                db_url : "/$databaseEngine/db",
+                query_url : "/$databaseEngine/query?queries=",
+                fortune_url : "/$databaseEngine/fortunes",
+                update_url : "/$databaseEngine/update?queries=",
                 plaintext_url : '/plaintext',
 
                 port : port,
@@ -151,7 +152,7 @@ task benchmarkConfig() {
                 display_name : "Hexagon $server $database",
                 notes : 'http://hexagonkt.com',
 
-                setup_file : "setup_${server.toLowerCase ()}_${database.toLowerCase ()}",
+                setup_file : "setup_${server.toLowerCase ()}_${databaseEngine}",
                 versus : 'servlet'
             ]
         }
@@ -189,7 +190,6 @@ task setupScripts() {
                 fw_depends java $database
 
                 ./gradlew -x test
-                export DBSTORE='$database'
                 export WEBENGINE='$server'
                 $command
             """.stripIndent ()

--- a/hexagon_benchmark/build.gradle
+++ b/hexagon_benchmark/build.gradle
@@ -133,7 +133,7 @@ task benchmarkConfig() {
                 json_url : '/json',
                 db_url : "/$databaseEngine/db",
                 query_url : "/$databaseEngine/query?queries=",
-                fortune_url : "/$databaseEngine/fortunes",
+                fortune_url : "/$databaseEngine/pebble/fortunes",
                 update_url : "/$databaseEngine/update?queries=",
                 plaintext_url : '/plaintext',
 

--- a/hexagon_benchmark/load_test.jmx
+++ b/hexagon_benchmark/load_test.jmx
@@ -22,6 +22,11 @@
             <stringProp name="Argument.value">mongodb</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="templateEngine" elementType="Argument">
+            <stringProp name="Argument.name">templateEngine</stringProp>
+            <stringProp name="Argument.value">pebble</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
           <elementProp name="users" elementType="Argument">
             <stringProp name="Argument.name">users</stringProp>
             <stringProp name="Argument.value">256</stringProp>
@@ -154,7 +159,7 @@
             <stringProp name="HTTPSampler.response_timeout"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/${databaseEngine}/fortunes</stringProp>
+            <stringProp name="HTTPSampler.path">/${databaseEngine}/${templateEngine}/fortunes</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -555,7 +560,7 @@
             <stringProp name="HTTPSampler.response_timeout"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/${databaseEngine}/fortunes</stringProp>
+            <stringProp name="HTTPSampler.path">/${databaseEngine}/${templateEngine}/fortunes</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>

--- a/hexagon_benchmark/load_test.jmx
+++ b/hexagon_benchmark/load_test.jmx
@@ -17,6 +17,11 @@
             <stringProp name="Argument.value">9040</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="databaseEngine" elementType="Argument">
+            <stringProp name="Argument.name">databaseEngine</stringProp>
+            <stringProp name="Argument.value">mongodb</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
           <elementProp name="users" elementType="Argument">
             <stringProp name="Argument.name">users</stringProp>
             <stringProp name="Argument.value">256</stringProp>
@@ -149,7 +154,7 @@
             <stringProp name="HTTPSampler.response_timeout"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/fortunes</stringProp>
+            <stringProp name="HTTPSampler.path">/${databaseEngine}/fortunes</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -183,7 +188,7 @@
             <stringProp name="HTTPSampler.response_timeout"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/db</stringProp>
+            <stringProp name="HTTPSampler.path">/${databaseEngine}/db</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -217,7 +222,7 @@
             <stringProp name="HTTPSampler.response_timeout"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/query</stringProp>
+            <stringProp name="HTTPSampler.path">/${databaseEngine}/query</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -245,7 +250,7 @@
             <stringProp name="HTTPSampler.response_timeout"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/query</stringProp>
+            <stringProp name="HTTPSampler.path">/${databaseEngine}/query</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -279,7 +284,7 @@
             <stringProp name="HTTPSampler.response_timeout"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/update</stringProp>
+            <stringProp name="HTTPSampler.path">/${databaseEngine}/update</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -307,7 +312,7 @@
             <stringProp name="HTTPSampler.response_timeout"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/update</stringProp>
+            <stringProp name="HTTPSampler.path">/${databaseEngine}/update</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -550,7 +555,7 @@
             <stringProp name="HTTPSampler.response_timeout"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/fortunes</stringProp>
+            <stringProp name="HTTPSampler.path">/${databaseEngine}/fortunes</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -573,7 +578,7 @@
             <stringProp name="HTTPSampler.response_timeout"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/db</stringProp>
+            <stringProp name="HTTPSampler.path">/${databaseEngine}/db</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -596,7 +601,7 @@
             <stringProp name="HTTPSampler.response_timeout"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/query</stringProp>
+            <stringProp name="HTTPSampler.path">/${databaseEngine}/query</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -624,7 +629,7 @@
             <stringProp name="HTTPSampler.response_timeout"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/query</stringProp>
+            <stringProp name="HTTPSampler.path">/${databaseEngine}/query</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -647,7 +652,7 @@
             <stringProp name="HTTPSampler.response_timeout"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/update</stringProp>
+            <stringProp name="HTTPSampler.path">/${databaseEngine}/update</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -675,7 +680,7 @@
             <stringProp name="HTTPSampler.response_timeout"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">/update</stringProp>
+            <stringProp name="HTTPSampler.path">/${databaseEngine}/update</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>

--- a/hexagon_benchmark/readme.md
+++ b/hexagon_benchmark/readme.md
@@ -15,23 +15,28 @@ development platforms. The test utilizes Hexagon routes, serialization and datab
 
 ## Test URLs
 
+In URLs replace `${DB_ENGINE}` with one of:
+
+* mongodb
+* postgresql
+
 ### Jetty
 
 * JSON Encoding Test: http://localhost:9090/json
-* Data-Store/Database Mapping Test: http://localhost:9090/db?queries=5 
 * Plain Text Test: http://localhost:9090/plaintext 
-* Fortunes: http://localhost:9090/fortunes
-* Database updates: http://localhost:9090/update
-* Database queries: http://localhost:9090/query
+* Data-Store/Database Mapping Test: http://localhost:9090/${DB_ENGINE}/db?queries=5 
+* Fortunes: http://localhost:9090/${DB_ENGINE}/fortunes
+* Database updates: http://localhost:9090/${DB_ENGINE}/update
+* Database queries: http://localhost:9090/${DB_ENGINE}/query
 
 ### Resin
 
 * JSON Encoding Test: http://localhost:8080/json
-* Data-Store/Database Mapping Test: http://localhost:8080/db?queries=5 
 * Plain Text Test: http://localhost:8080/plaintext 
-* Fortunes: http://localhost:8080/fortunes
-* Database updates: http://localhost:8080/update
-* Database queries: http://localhost:8080/query
+* Data-Store/Database Mapping Test: http://localhost:8080/${DB_ENGINE}/db?queries=5 
+* Fortunes: http://localhost:8080/${DB_ENGINE}/fortunes
+* Database updates: http://localhost:8080/${DB_ENGINE}/update
+* Database queries: http://localhost:8080/${DB_ENGINE}/query
 
 ## Run inside vagrant
 

--- a/hexagon_benchmark/readme.md
+++ b/hexagon_benchmark/readme.md
@@ -20,12 +20,17 @@ In URLs replace `${DB_ENGINE}` with one of:
 * mongodb
 * postgresql
 
+and `${TEMPLATE_ENGINE}` with one of:
+
+* pebble
+* rocker
+
 ### Jetty
 
 * JSON Encoding Test: http://localhost:9090/json
 * Plain Text Test: http://localhost:9090/plaintext 
 * Data-Store/Database Mapping Test: http://localhost:9090/${DB_ENGINE}/db?queries=5 
-* Fortunes: http://localhost:9090/${DB_ENGINE}/fortunes
+* Fortunes: http://localhost:9090/${DB_ENGINE}/${TEMPLATE_ENGINE}/fortunes
 * Database updates: http://localhost:9090/${DB_ENGINE}/update
 * Database queries: http://localhost:9090/${DB_ENGINE}/query
 
@@ -34,7 +39,7 @@ In URLs replace `${DB_ENGINE}` with one of:
 * JSON Encoding Test: http://localhost:8080/json
 * Plain Text Test: http://localhost:8080/plaintext 
 * Data-Store/Database Mapping Test: http://localhost:8080/${DB_ENGINE}/db?queries=5 
-* Fortunes: http://localhost:8080/${DB_ENGINE}/fortunes
+* Fortunes: http://localhost:8080/${DB_ENGINE}/${TEMPLATE_ENGINE}/fortunes
 * Database updates: http://localhost:8080/${DB_ENGINE}/update
 * Database queries: http://localhost:8080/${DB_ENGINE}/query
 

--- a/hexagon_benchmark/src/main/kotlin/com/hexagonkt/Benchmark.kt
+++ b/hexagon_benchmark/src/main/kotlin/com/hexagonkt/Benchmark.kt
@@ -32,6 +32,7 @@ private const val QUERIES_PARAM = "queries"
 private val contentTypeJson = JsonFormat.contentType
 private val logger: Logger = getLogger("BENCHMARK_LOGGER")
 private val defaultLocale: Locale = Locale.getDefault()
+private val storageEngines = listOf("mongodb", "postgresql")
 
 // UTILITIES
 internal fun randomWorld() = ThreadLocalRandom.current().nextInt(WORLD_ROWS) + 1
@@ -79,7 +80,9 @@ private fun Call.updateWorlds(store: Store) {
 
 // CONTROLLER
 private fun router(): Router = router {
-    val store = benchmarkStore ?: error("Invalid Store")
+    if (benchmarkStores == null) {
+        error("Invalid Stores")
+    }
 
     before {
         response.addHeader("Server", "Servlet/3.1")
@@ -89,16 +92,19 @@ private fun router(): Router = router {
 
     get("/plaintext") { ok(TEXT_MESSAGE, "text/plain") }
     get("/json") { ok(Message(TEXT_MESSAGE).serialize(), contentTypeJson) }
-    get("/fortunes") { listFortunes(store) }
-    get("/db") { dbQuery(store) }
-    get("/query") { getWorlds(store) }
-    get("/update") { updateWorlds(store) }
+    benchmarkStores?.forEach({ (storeEngine, store) ->
+        get("/$storeEngine/fortunes") { listFortunes(store) }
+        get("/$storeEngine/db") { dbQuery(store) }
+        get("/$storeEngine/query") { getWorlds(store) }
+        get("/$storeEngine/update") { updateWorlds(store) }
+    })
 }
 
 @WebListener class Web : ServletServer () {
     init {
-        if (benchmarkStore == null)
-            benchmarkStore = createStore(systemSetting("DBSTORE", "mongodb"))
+        if (benchmarkStores == null) {
+            benchmarkStores = storageEngines.map { it to createStore(it) }.toMap()
+        }
     }
 
     override fun createRouter() = router()
@@ -110,7 +116,7 @@ fun getTemplateEngine(engine: String): TemplateEngine = when (engine) {
     else -> error("Unsupported template engine: $engine")
 }
 
-internal var benchmarkStore: Store? = null
+internal var benchmarkStores: Map<String, Store>? = null
 internal var benchmarkServer: Server? = null
 
 internal fun createEngine(engine: String): ServerEngine = when (engine) {
@@ -121,17 +127,17 @@ internal fun createEngine(engine: String): ServerEngine = when (engine) {
 
 fun main(vararg args: String) {
     val engine = createEngine(systemSetting("WEBENGINE", "jetty"))
-    benchmarkStore = createStore(systemSetting("DBSTORE", "mongodb"))
+    benchmarkStores = storageEngines.map { it to createStore(it) }.toMap()
 
     logger.info("""
             Benchmark set up:
                 - Engine: {}
                 - Templates: {}
-                - Store: {}
+                - Stores: {}
         """.trimIndent(),
         engine.javaClass.name,
         systemSetting("TEMPLATE_ENGINE", "pebble"),
-        benchmarkStore?.javaClass?.name)
+        storageEngines)
 
     benchmarkServer = Server(engine, settings, router()).apply { run() }
 }

--- a/hexagon_benchmark/src/test/kotlin/com/hexagonkt/BenchmarkTest.kt
+++ b/hexagon_benchmark/src/test/kotlin/com/hexagonkt/BenchmarkTest.kt
@@ -33,7 +33,6 @@ abstract class BenchmarkTest(
 
     @BeforeClass fun warmup() {
         setProperty("WEBENGINE", webEngine)
-        setProperty("TEMPLATE_ENGINE", templateEngine)
         main()
 
         @Suppress("ConstantConditionIf")
@@ -83,7 +82,7 @@ abstract class BenchmarkTest(
         val benchmarkRoutes = listOf(
             GET to "/plaintext",
             GET to "/json",
-            GET to "/$databaseEngine/fortunes",
+            GET to "/$databaseEngine/$templateEngine/fortunes",
             GET to "/$databaseEngine/db",
             GET to "/$databaseEngine/query",
             GET to "/$databaseEngine/update"
@@ -109,7 +108,7 @@ abstract class BenchmarkTest(
     }
 
     fun fortunes() {
-        val response = client.get("/$databaseEngine/fortunes")
+        val response = client.get("/$databaseEngine/$templateEngine/fortunes")
         val content = response.responseBody
 
         checkResponse(response, "text/html;charset=utf-8")

--- a/hexagon_benchmark/src/test/kotlin/com/hexagonkt/BenchmarkTest.kt
+++ b/hexagon_benchmark/src/test/kotlin/com/hexagonkt/BenchmarkTest.kt
@@ -32,7 +32,6 @@ abstract class BenchmarkTest(
     private val client by lazy { Client("http://localhost:${benchmarkServer?.runtimePort}") }
 
     @BeforeClass fun warmup() {
-        setProperty("DBSTORE", databaseEngine)
         setProperty("WEBENGINE", webEngine)
         setProperty("TEMPLATE_ENGINE", templateEngine)
         main()
@@ -65,7 +64,7 @@ abstract class BenchmarkTest(
     }
 
     @AfterClass fun cooldown() {
-        benchmarkStore?.close()
+        benchmarkStores?.get(databaseEngine)?.close()
         benchmarkServer?.stop()
     }
 
@@ -84,10 +83,10 @@ abstract class BenchmarkTest(
         val benchmarkRoutes = listOf(
             GET to "/plaintext",
             GET to "/json",
-            GET to "/fortunes",
-            GET to "/db",
-            GET to "/query",
-            GET to "/update"
+            GET to "/$databaseEngine/fortunes",
+            GET to "/$databaseEngine/db",
+            GET to "/$databaseEngine/query",
+            GET to "/$databaseEngine/update"
         )
 
         assert(webRoutes.containsAll(benchmarkRoutes))
@@ -110,7 +109,7 @@ abstract class BenchmarkTest(
     }
 
     fun fortunes() {
-        val response = client.get("/fortunes")
+        val response = client.get("/$databaseEngine/fortunes")
         val content = response.responseBody
 
         checkResponse(response, "text/html;charset=utf-8")
@@ -120,7 +119,7 @@ abstract class BenchmarkTest(
     }
 
     fun `no query parameter`() {
-        val response = client.get("/db")
+        val response = client.get("/$databaseEngine/db")
         val body = response.responseBody
 
         checkResponse(response, JsonFormat.contentType)
@@ -130,7 +129,7 @@ abstract class BenchmarkTest(
     }
 
     fun `no updates parameter`() {
-        val response = client.get("/update")
+        val response = client.get("/$databaseEngine/update")
         val body = response.responseBody
 
         checkResponse(response, JsonFormat.contentType)
@@ -139,23 +138,23 @@ abstract class BenchmarkTest(
         assert(bodyMap.containsKey(World::randomNumber.name))
     }
 
-    fun `empty query parameter`() = checkDbRequest("/query?queries", 1)
-    fun `text query parameter`() = checkDbRequest("/query?queries=text", 1)
-    fun `zero queries`() = checkDbRequest("/query?queries=0", 1)
-    fun `one thousand queries`() = checkDbRequest("/query?queries=1000", 500)
-    fun `one query`() = checkDbRequest("/query?queries=1", 1)
-    fun `ten queries`() = checkDbRequest("/query?queries=10", 10)
-    fun `one hundred queries`() = checkDbRequest("/query?queries=100", 100)
-    fun `five hundred queries`() = checkDbRequest("/query?queries=500", 500)
+    fun `empty query parameter`() = checkDbRequest("/$databaseEngine/query?queries", 1)
+    fun `text query parameter`() = checkDbRequest("/$databaseEngine/query?queries=text", 1)
+    fun `zero queries`() = checkDbRequest("/$databaseEngine/query?queries=0", 1)
+    fun `one thousand queries`() = checkDbRequest("/$databaseEngine/query?queries=1000", 500)
+    fun `one query`() = checkDbRequest("/$databaseEngine/query?queries=1", 1)
+    fun `ten queries`() = checkDbRequest("/$databaseEngine/query?queries=10", 10)
+    fun `one hundred queries`() = checkDbRequest("/$databaseEngine/query?queries=100", 100)
+    fun `five hundred queries`() = checkDbRequest("/$databaseEngine/query?queries=500", 500)
 
-    fun `empty updates parameter`() = checkDbRequest("/update?queries", 1)
-    fun `text updates parameter`() = checkDbRequest("/update?queries=text", 1)
-    fun `zero updates`() = checkDbRequest("/update?queries=0", 1)
-    fun `one thousand updates`() = checkDbRequest("/update?queries=1000", 500)
-    fun `one update`() = checkDbRequest("/update?queries=1", 1)
-    fun `ten updates`() = checkDbRequest("/update?queries=10", 10)
-    fun `one hundred updates`() = checkDbRequest("/update?queries=100", 100)
-    fun `five hundred updates`() = checkDbRequest("/update?queries=500", 500)
+    fun `empty updates parameter`() = checkDbRequest("/$databaseEngine/update?queries", 1)
+    fun `text updates parameter`() = checkDbRequest("/$databaseEngine/update?queries=text", 1)
+    fun `zero updates`() = checkDbRequest("/$databaseEngine/update?queries=0", 1)
+    fun `one thousand updates`() = checkDbRequest("/$databaseEngine/update?queries=1000", 500)
+    fun `one update`() = checkDbRequest("/$databaseEngine/update?queries=1", 1)
+    fun `ten updates`() = checkDbRequest("/$databaseEngine/update?queries=10", 10)
+    fun `one hundred updates`() = checkDbRequest("/$databaseEngine/update?queries=100", 100)
+    fun `five hundred updates`() = checkDbRequest("/$databaseEngine/update?queries=500", 500)
 
     private fun checkDbRequest(path: String, itemsCount: Int) {
         val response = client.get(path)


### PR DESCRIPTION
This way one server can be used to test against different database
and template engines and doesn't need to be restarted to test a
different engine.

Remove unnecessary combinations of docker based benchmark servers, it
is now enough to have one per web engine (Resin, Jetty, Undertow).
Also remove links definitions as they are not needed in compose v2+
(services in a stack are by default addressable by their name).

Close #97 
