### PR TITLE
Fixed HTTP Client example documentation

### DIFF
--- a/hexagon_site/pages/examples/http_client_examples.md
+++ b/hexagon_site/pages/examples/http_client_examples.md
@@ -1,7 +1,7 @@
 
 # HTTP Request Example
 
-Simple example to show how to make HTTP requests using a HTTP Client.
-[full test](https://github.com/hexagonkt/hexagon/blob/master/port_http_server/src/test/kotlin/examples/BooksTest.kt).
+This example shows the HTTP Client used to test the [HTTP Server Books Example](../http_server_examples/#books-example). [full test](https://github.com/hexagonkt/hexagon/blob/master/port_http_server/src/test/kotlin/examples/BooksTest.kt).
 
-@sample port_http_server/src/test/kotlin/examples/BooksTest.kt:books
+@sample port_http_server/src/test/kotlin/examples/BooksTest.kt:client_init
+@sample port_http_server/src/test/kotlin/examples/BooksTest.kt:client_usage

--- a/port_http_server/src/test/kotlin/examples/BooksTest.kt
+++ b/port_http_server/src/test/kotlin/examples/BooksTest.kt
@@ -77,9 +77,11 @@ abstract class BooksTest(adapter: ServerPort) {
     }
     // books
 
+    // client_init
     private val client: Client by lazy {
         Client(AhcAdapter(), "http://localhost:${server.runtimePort}")
     }
+    // client_init
 
     @BeforeAll fun initialize() {
         server.start()
@@ -89,6 +91,7 @@ abstract class BooksTest(adapter: ServerPort) {
         server.stop()
     }
 
+    // client_usage
     @Test fun `Create book returns 201 and new book ID`() {
         val result = client.post("/books?author=Vladimir%20Nabokov&title=Lolita")
         assert(Integer.valueOf(result.body) > 0)
@@ -127,6 +130,7 @@ abstract class BooksTest(adapter: ServerPort) {
         val result = client.options("/books/9999")
         assert(405 == result.status)
     }
+    // client_usage
 
     private fun assertResponseContains(response: Response?, status: Int, vararg content: String) {
         assert(response?.status == status)


### PR DESCRIPTION
- Made a minor change so that the HTTP Client Example in hexagon_site displays the example code of the Client instead of code for the Server
- Added link to the Server Books example to give context for the HTTP Client example
