### PR TITLE
fix error parsing query params #328

### DIFF
--- a/hexagon_http/src/main/kotlin/Http.kt
+++ b/hexagon_http/src/main/kotlin/Http.kt
@@ -51,16 +51,17 @@ fun parseQueryParameters (query: String): Map<String, List<String>> =
     if (query.isBlank())
         mapOf()
     else
-        query.split("&".toRegex())
+        query.replace("\\s".toRegex(), "")
+            .split("&".toRegex())
             .map {
                 val keyValue = it.split("=").map(String::trim)
                 val key = keyValue[0]
                 val value = if (keyValue.size == 2) keyValue[1] else ""
                 key.urlDecode() to value.urlDecode()
             }
+            .filter { it.first.isNotBlank() }
             .groupBy { it.first }
             .mapValues { pair -> pair.value.map { it.second } }
-            .mapValues { if (it.value == listOf("")) emptyList() else it.value }
 
 fun httpDate (date: LocalDateTime = LocalDateTime.now()): String =
     RFC_1123_DATE_TIME.format(ZonedDateTime.of(date, ZoneId.of("GMT")))

--- a/hexagon_http/src/test/kotlin/HttpTest.kt
+++ b/hexagon_http/src/test/kotlin/HttpTest.kt
@@ -8,8 +8,8 @@ class HttpTest {
     @Test fun `Parse strips spaces` () {
         assert(parseQueryParameters("a =1&b & c &d = e") == mapOf(
             "a" to listOf("1"),
-            "b" to emptyList(),
-            "c" to emptyList(),
+            "b" to listOf(""),
+            "c" to listOf(""),
             "d" to listOf("e")
         ))
     }
@@ -17,8 +17,8 @@ class HttpTest {
     @Test fun `Parse key only query parameters return correct data` () {
         assert(parseQueryParameters("a=1&b&c&d=e") == mapOf(
             "a" to listOf("1"),
-            "b" to emptyList(),
-            "c" to emptyList(),
+            "b" to listOf(""),
+            "c" to listOf(""),
             "d" to listOf("e")
         ))
     }
@@ -27,9 +27,38 @@ class HttpTest {
         assert(parseQueryParameters("a=1&b&c&d=e&a=2&b=c") == mapOf(
             "a" to listOf("1", "2"),
             "b" to listOf("", "c"),
-            "c" to emptyList(),
+            "c" to listOf(""),
             "d" to listOf("e")
         ))
+    }
+
+    @Test fun `Parse multiple empty values` () {
+        assert(parseQueryParameters("a=") == mapOf(
+            "a" to listOf("")
+        ))
+        assert(parseQueryParameters("a=&b=") == mapOf(
+            "a" to listOf(""),
+            "b" to listOf("")
+        ))
+        assert(parseQueryParameters("a=&b=&c") == mapOf(
+            "a" to listOf(""),
+            "b" to listOf(""),
+            "c" to listOf("")
+        ))
+    }
+
+    @Test fun `Parse key only` () {
+        assert(parseQueryParameters("ab") == mapOf(
+            "ab" to listOf("")
+        ))
+    }
+
+    @Test fun `Parse value only` () {
+        assert(parseQueryParameters(" =ab").none())
+    }
+
+    @Test fun `Parse white space only`() {
+        assert(parseQueryParameters("    ").none())
     }
 
     @Test fun `HTTP date has the correct format`() {

--- a/messaging_rabbitmq/src/main/kotlin/RabbitMqClient.kt
+++ b/messaging_rabbitmq/src/main/kotlin/RabbitMqClient.kt
@@ -41,10 +41,10 @@ class RabbitMqClient(
             cf.setUri(uri)
 
             val params = parseQueryParameters(uri.query ?: "")
-            val automaticRecovery = params["automaticRecovery"]?.firstOrNull()?.toBoolean()
-            val recoveryInterval = params["recoveryInterval"]?.firstOrNull()?.toLong()
-            val shutdownTimeout = params["shutdownTimeout"]?.firstOrNull()?.toInt()
-            val heartbeat = params["heartbeat"]?.firstOrNull()?.toInt()
+            val automaticRecovery = params["automaticRecovery"]?.firstOrNull { it.isNotBlank() }?.toBoolean()
+            val recoveryInterval = params["recoveryInterval"]?.firstOrNull{ it.isNotBlank() }?.toLong()
+            val shutdownTimeout = params["shutdownTimeout"]?.firstOrNull{ it.isNotBlank() }?.toInt()
+            val heartbeat = params["heartbeat"]?.firstOrNull{ it.isNotBlank() }?.toInt()
             val metricsCollector = StandardMetricsCollector(MetricRegistry())
 
             setVar(automaticRecovery) { cf.isAutomaticRecoveryEnabled = it }


### PR DESCRIPTION
- whitespace characters replaced with empty string
- filtering missing keys (=ab) out
- as parseQueryParameters() can return a map that contains empty string as value. We need to filter those or conversion fails (toBolean() etc.)
- several basic tests added


---

For the Pull Request to be accepted please check:

- [ ] The PR has a meaningful title.
- [ ] If the PR refers to an issue, it should be referenced with the Github format (*#ID*).
- [ ] The PR is done to the `develop` branch.
- [ ] The code pass all PR checks.
- [ ] All public members are documented using [Dokka](https://github.com/Kotlin/dokka).
- [ ] The code follow the coding conventions stated at the [contributing.md](/contributing.md) file.
