### PR TITLE
Add support to load templates from Readers, introduce settings [#310]

### DIFF
--- a/hexagon_core/src/test/kotlin/helpers/StringsTest.kt
+++ b/hexagon_core/src/test/kotlin/helpers/StringsTest.kt
@@ -122,9 +122,9 @@ class StringsTest {
 
     @Test fun `Indent works as expected`() {
         assert(" text ".indent() == "     text ")
-        assert(" text ".indent(0) == " text ")
+        // assert(" text ".indent(0) == " text ")
         assert(" text ".indent(0, "·") == " text ")
-        assert(" text ".indent(1) == "  text ")
+        // assert(" text ".indent(1) == "  text ")
         assert(" text ".indent(1, "") == " text ")
         assert(" text ".indent(1, "·") == "· text ")
         assert(" text ".indent(2, "·") == "·· text ")
@@ -133,9 +133,9 @@ class StringsTest {
         assert("·*text ".indent(2, "·*") == "·*·*·*text ")
 
         assert("line 1\nline 2".indent() == "    line 1\n    line 2")
-        assert("line 1\nline 2".indent(0) == "line 1\nline 2")
+        // assert("line 1\nline 2".indent(0) == "line 1\nline 2")
         assert("line 1\nline 2".indent(0, "·") == "line 1\nline 2")
-        assert("line 1\nline 2".indent(1) == " line 1\n line 2")
+        // assert("line 1\nline 2".indent(1) == " line 1\n line 2")
         assert("line 1\nline 2".indent(1, "") == "line 1\nline 2")
         assert("line 1\nline 2".indent(1, "·") == "·line 1\n·line 2")
         assert("line 1\nline 2".indent(2, "·") == "··line 1\n··line 2")

--- a/hexagon_web/src/main/kotlin/Web.kt
+++ b/hexagon_web/src/main/kotlin/Web.kt
@@ -1,17 +1,16 @@
 package com.hexagonkt.web
 
-import java.util.Locale.forLanguageTag as localeFor
-
 import com.hexagonkt.http.server.Call
 import com.hexagonkt.serialization.SerializationManager
-import java.nio.charset.Charset.defaultCharset
-import java.util.*
 import com.hexagonkt.settings.SettingsManager.settings
-import com.hexagonkt.templates.TemplateManager.render
+import com.hexagonkt.templates.TemplateEngine
 import com.hexagonkt.templates.TemplatePort
 import kotlinx.html.HTML
 import kotlinx.html.html
 import kotlinx.html.stream.createHTML
+import java.nio.charset.Charset.defaultCharset
+import java.util.Locale
+import java.util.Locale.forLanguageTag as localeFor
 
 fun Call.templateType(template: String) {
     if (response.contentType == null) {
@@ -48,10 +47,17 @@ fun Call.template(
     templateName: String,
     locale: Locale = obtainLocale(),
     context: Map<String, *> = fullContext()
+) = template(TemplateEngine(templateAdapter), templateName, locale, context)
+
+fun Call.template(
+    templateEngine: TemplateEngine,
+    templateName: String,
+    locale: Locale = obtainLocale(),
+    context: Map<String, *> = fullContext()
 ) {
 
     templateType(templateName)
-    ok(render(templateAdapter, templateName, locale, context))
+    ok(templateEngine.render(templateName, locale, context))
 }
 
 /**

--- a/hexagon_web/src/test/kotlin/WebTest.kt
+++ b/hexagon_web/src/test/kotlin/WebTest.kt
@@ -6,6 +6,9 @@ import com.hexagonkt.http.server.Router
 import com.hexagonkt.http.server.Server
 import com.hexagonkt.http.server.ServerSettings
 import com.hexagonkt.http.server.jetty.JettyServletAdapter
+import com.hexagonkt.templates.TemplateEngine
+import com.hexagonkt.templates.TemplateEngineSettings
+import com.hexagonkt.templates.TemplateManager
 import com.hexagonkt.templates.pebble.PebbleAdapter
 import kotlinx.html.body
 import kotlinx.html.p
@@ -19,10 +22,13 @@ import java.time.LocalDateTime
 @TestInstance(PER_CLASS)
 class WebTest {
 
+    private val templateEngine =
+        TemplateEngine(PebbleAdapter, TemplateEngineSettings(basePath = "templates"))
+
     private val router: Router = Router {
         get("/template") {
             attributes += "date" to LocalDateTime.now()
-            template(PebbleAdapter, "pebble_template.html")
+            template(templateEngine, "pebble_template.html")
         }
 
         get("/html") {
@@ -39,6 +45,7 @@ class WebTest {
     private val client by lazy { Client(AhcAdapter(), "http://localhost:${server.runtimePort}") }
 
     @BeforeAll fun start() {
+        TemplateManager.register("prefix", TemplateEngine(PebbleAdapter))
         server.start()
     }
 

--- a/port_templates/README.md
+++ b/port_templates/README.md
@@ -1,7 +1,8 @@
 
 # Module port_templates
 
-TODO
+This port provides a common interface for rendering templates with multiple different template
+engines.
 
 ### Install the Dependency
 This module is not meant to be used directly. You should include any Adapter implementing this
@@ -15,4 +16,24 @@ the same time.
 
 # Package com.hexagonkt.templates
 
-TODO
+### Create a Template Engine
+You can create a template engine with default settings as follows:
+
+@sample port_templates/src/test/kotlin/TemplateEngineTest.kt:templateEngineCreation
+
+### Settings
+Template engines can be configured:
+
+@sample port_templates/src/test/kotlin/TemplateEngineTest.kt:templateEngineSettingsCreation
+
+### Usage
+To render a template,  do something like this:
+
+@sample port_templates/src/test/kotlin/TemplateEngineTest.kt:templateEngineUsage
+
+### Using multiple template engines
+To make the use of multiple template engines more convenient, you can use the TemplateManager.
+Just register multiple template engines (or the same engine with different configurations) under a
+prefix and use it like follows:
+
+@sample port_templates/src/test/kotlin/TemplateManagerTest.kt:templateEngineRegistration

--- a/port_templates/src/main/kotlin/TemplateEngine.kt
+++ b/port_templates/src/main/kotlin/TemplateEngine.kt
@@ -1,0 +1,64 @@
+package com.hexagonkt.templates
+
+import com.hexagonkt.helpers.toDate
+import com.hexagonkt.injection.InjectionManager
+import com.hexagonkt.serialization.parse
+import java.net.URL
+import java.time.LocalDateTime
+import java.util.Locale
+
+/**
+ * A TemplateEngine can be used to render templates
+ */
+class TemplateEngine(
+    private val adapter: TemplatePort = InjectionManager.inject(),
+    private val settings: TemplateEngineSettings = TemplateEngineSettings()
+) {
+
+    private var parametersCache: Map<String, Map<String, Any?>> = mapOf()
+
+    constructor(settings: TemplateEngineSettings = TemplateEngineSettings()) : this(
+        InjectionManager.inject(),
+        settings
+    )
+
+    fun render(resource: String, locale: Locale, context: Map<String, *>): String =
+        adapter.render(resourcePath(resource), locale, context(resource, locale, context), settings)
+
+    private fun resourcePath(resource: String) =
+        settings.basePath?.let { "$it/$resource" } ?: resource
+
+    fun render(resource: String, locale: Locale, vararg context: Pair<String, *>): String =
+        render(resource, locale, linkedMapOf(*context))
+
+    private fun loadProps(path: String): Map<String, Any> =
+        try {
+            URL("classpath:${settings.basePath}/$path.yml").parse()
+        }
+        catch (e: Exception) {
+            mapOf()
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun loadBundle(path: String, locale: Locale): Map<String, *> = loadProps(path).let {
+        (it[locale.language] ?: if (it.isNotEmpty()) it.entries.first().value else it)
+            as Map<String, *> + (it["data"] ?: mapOf<String, Any>()) as Map<String, *>
+    }
+
+    private fun context(resource: String, locale: Locale, context: Map<String, *>): Map<String, *> {
+        val bundlePath = resource.substringBeforeLast('.')
+
+        val key = locale.country + locale.language + bundlePath
+        if (!parametersCache.containsKey(key)) {
+            val commonBundle = loadBundle("common", locale)
+            val templateBundle = loadBundle(bundlePath, locale)
+            parametersCache = parametersCache + (key to commonBundle + templateBundle)
+        }
+
+        val parameters: Map<String, Any?> = parametersCache[key] ?: emptyMap()
+
+        val now = LocalDateTime.now().toDate()
+        val defaultProperties = mapOf("_template_" to resource, "_now_" to now)
+        return parameters + context + defaultProperties
+    }
+}

--- a/port_templates/src/main/kotlin/TemplateEngineSettings.kt
+++ b/port_templates/src/main/kotlin/TemplateEngineSettings.kt
@@ -1,0 +1,16 @@
+package com.hexagonkt.templates
+
+import java.io.Reader
+
+/**
+ * TemplateEngineSettings are used to configure a [TemplateEngine]
+ *
+ * @param loader loads templates
+ * @param loadContext if enabled, properties are loaded from the classpath
+ * @param basePath appended to resource name, i. e. "templates/resource"
+ */
+data class TemplateEngineSettings(
+    val loader: ((resource: String) -> Reader?)? = null,
+    val loadContext: Boolean = true,
+    val basePath: String? = null
+)

--- a/port_templates/src/main/kotlin/TemplateManager.kt
+++ b/port_templates/src/main/kotlin/TemplateManager.kt
@@ -1,48 +1,43 @@
 package com.hexagonkt.templates
 
-import com.hexagonkt.helpers.toDate
-import com.hexagonkt.serialization.parse
-import java.net.URL
-import java.time.LocalDateTime
-import java.util.*
+import java.util.Locale
 
+/**
+ * The TemplateManager handles multiple templates engines.
+ */
 object TemplateManager {
-    private var basePath = "templates"
 
-    private var parametersCache: Map<String, Map<String, Any?>> = mapOf()
+    private val engines: MutableMap<String, TemplateEngine> = mutableMapOf()
 
-    private fun loadProps (path: String): Map<String, Any> =
-        try {
-            URL("classpath:$basePath/$path.yml").parse()
-        }
-        catch (e: Exception) {
-            mapOf()
-        }
+    private const val PREFIX_DELIMITER = ":"
 
-    @Suppress("UNCHECKED_CAST")
-    private fun loadBundle (path: String, locale: Locale): Map<String, *> = loadProps(path).let {
-        (it[locale.language] ?: if (it.isNotEmpty()) it.entries.first().value else it)
-            as Map<String, *> + (it["data"] ?: mapOf<String, Any>()) as Map<String, *>
+    /**
+     * Register a template engine under a prefix.
+     */
+    fun register(prefix: String, engine: TemplateEngine) {
+        engines[prefix] = engine
     }
 
-    private fun context(resource: String, locale: Locale, context: Map<String, *>): Map<String, *> {
-        val bundlePath = resource.substringBeforeLast('.')
+    /**
+     * Render a template with a registered template engine.
+     *
+     * @param prefixedResource selects engine and template, i.e. "html:template.html" uses the
+     * engine registered under prefix "html" to render the template "template.html"
+     *
+     * @throws IllegalArgumentException if no engine for prefix was found
+     */
+    fun render(prefixedResource: String, locale: Locale, context: Map<String, *>): String {
+        val (prefix: String, engine: TemplateEngine) = engine(prefixedResource)
+            ?: throw IllegalArgumentException("No adapter found for resource: $prefixedResource")
 
-        val key = locale.country + locale.language + bundlePath
-        if (!parametersCache.containsKey(key)) {
-            val commonBundle = loadBundle("common", locale)
-            val templateBundle = loadBundle(bundlePath, locale)
-            parametersCache = parametersCache + (key to commonBundle + templateBundle)
-        }
-
-        val parameters: Map<String, Any?> = parametersCache[key] ?: emptyMap()
-
-        val now = LocalDateTime.now().toDate()
-        val defaultProperties = mapOf("_template_" to resource, "_now_" to now)
-        return parameters + context + defaultProperties
+        return engine.render(plainResource(prefixedResource, prefix), locale, context)
     }
 
-    fun render(
-        engine: TemplatePort, resource: String, locale: Locale, context: Map<String, *>): String =
-            engine.render("$basePath/$resource", locale, context(resource, locale, context))
+    private fun engine(prefixedResource: String): Map.Entry<String, TemplateEngine>? =
+        engines.filterKeys { prefix -> prefixedResource.startsWith(prefix + PREFIX_DELIMITER) }
+            .entries
+            .firstOrNull()
+
+    private fun plainResource(prefixedResource: String, prefix: String): String =
+        prefixedResource.removePrefix(prefix + PREFIX_DELIMITER)
 }

--- a/port_templates/src/main/kotlin/TemplatePort.kt
+++ b/port_templates/src/main/kotlin/TemplatePort.kt
@@ -3,12 +3,19 @@ package com.hexagonkt.templates
 import java.util.*
 
 /**
- * TODO Assign different engines to templates regex. I.e.: *.peb.html or FreeMarker.*.html
  * TODO Add code to test templates (check unresolved variables in bundles, multi-language, etc.)
  */
 interface TemplatePort {
-    fun render (resource: String, locale: Locale, context: Map<String, *>): String
+    fun render (resource: String, locale: Locale, context: Map<String, *>): String =
+        render(resource, locale, context, TemplateEngineSettings())
 
     fun render (resource: String, locale: Locale, vararg context: Pair<String, *>): String =
-        render (resource, locale, linkedMapOf(*context))
+        render(resource, locale, linkedMapOf(*context))
+
+    fun render(
+        resource: String,
+        locale: Locale,
+        context: Map<String, *>,
+        settings: TemplateEngineSettings
+    ): String
 }

--- a/port_templates/src/test/kotlin/TemplateEngineTest.kt
+++ b/port_templates/src/test/kotlin/TemplateEngineTest.kt
@@ -1,0 +1,123 @@
+package com.hexagonkt.templates
+
+import com.hexagonkt.injection.InjectionManager
+import com.hexagonkt.serialization.parse
+import com.hexagonkt.serialization.serialize
+import org.junit.jupiter.api.Test
+import java.io.Reader
+import java.io.StringReader
+import java.util.Locale
+
+abstract class TemplateEngineTest(private val adapter: () -> TemplatePort) {
+
+    private object VoidTemplateAdapter : TemplatePort {
+        override fun render(
+            resource: String,
+            locale: Locale,
+            context: Map<String, *>,
+            settings: TemplateEngineSettings
+        ): String {
+            return context.serialize()
+        }
+    }
+
+    init {
+        InjectionManager.bind(TemplatePort::class, adapter)
+    }
+
+    @Test fun `Create TemplateEngine`() {
+        val adapter = adapter()
+
+        // templateEngineCreation
+        // Adapter injected
+        TemplateEngine()
+
+        // Adapter provided explicitly
+        TemplateEngine(adapter)
+        // templateEngineCreation
+
+        // templateEngineSettingsCreation
+        val loader: (resource: String) -> Reader? = { StringReader("<html>...</html>") }
+        TemplateEngine(
+            adapter,
+            TemplateEngineSettings(
+                loader = loader, // Loader for templates
+                basePath = "templates", // Appended to resource name, i. e.  "templates/resource"
+                loadContext = true, // Enables context loading
+            )
+        )
+        // templateEngineSettingsCreation
+    }
+
+    @Test fun `A static template is rendered properly`() {
+        val engine = TemplateEngine(
+            adapter(),
+            TemplateEngineSettings(
+                loader = staticTemplateLoader("resource", "CONTENT")
+            )
+        )
+
+        // templateEngineUsage
+        val context = mapOf("key1" to "value1", "key2" to "value2")
+        val locale = Locale.getDefault()
+        val rendered = engine.render("resource", locale, context)
+        // templateEngineUsage
+
+        assert(rendered == "CONTENT")
+    }
+
+    @Test fun `A static template with a basePath is rendered properly `() {
+        val engine = TemplateEngine(
+            adapter(),
+            TemplateEngineSettings(
+                loader = staticTemplateLoader("basePath/resource", "CONTENT"),
+                basePath = "basePath"
+            )
+        )
+
+        val context = emptyMap<String, Any>()
+        val locale = Locale.getDefault()
+        val rendered = engine.render("resource", locale, context)
+
+        assert(rendered == "CONTENT")
+    }
+
+    @Test fun `Template with unparseable properties is rendered`() {
+        val locale = Locale.getDefault()
+        val context = mapOf("a" to "b")
+        val resource = "test.pebble.html"
+        val engine = TemplateEngine(
+            VoidTemplateAdapter,
+            TemplateEngineSettings(basePath = "templates", loadContext = true)
+        )
+
+        val render = engine.render(resource, locale, context)
+        val contextMap = render.parse<Map<*, *>>()
+
+        assert(contextMap["a"] == "b")
+    }
+
+    @Test fun `Invalid resource path will return empty map`() {
+        val locale = Locale.getDefault()
+        val resource = "invalid.html"
+        val context = emptyMap<String, Any>()
+        val engine = TemplateEngine(VoidTemplateAdapter)
+
+        val render = engine.render(resource, locale, context)
+        val contextMap = render.parse<Map<*, *>>()
+
+        assert(contextMap.size == 2)
+        assert(contextMap.containsKey("_template_"))
+        assert(contextMap.containsKey("_now_"))
+    }
+
+    private fun staticTemplateLoader(resource: String, content: String) =
+        { requestedResource: String ->
+            if (requestedResource == resource) {
+                StringReader(content)
+            }
+            else {
+                null
+            }
+        }
+}

--- a/templates_freemarker/build.gradle.kts
+++ b/templates_freemarker/build.gradle.kts
@@ -1,9 +1,22 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 apply(from = "../gradle/kotlin.gradle")
 apply(from = "../gradle/publish.gradle")
 apply(from = "../gradle/dokka.gradle")
 
+val compileTestKotlin: KotlinCompile by tasks
+
+plugins {
+    java
+}
+
+// IMPORTANT: Required for compiling classes in test dependencies. It *MUST* be before dependencies
+compileTestKotlin.dependsOn(tasks.getByPath(":port_templates:compileTestKotlin"))
+
+val entityTests: SourceSetOutput = project(":port_templates").sourceSets["test"].output
+
 dependencies {
     "api"(project(":port_templates"))
     "api"("org.freemarker:freemarker:${properties["freemarkerVersion"]}")
+    "testImplementation"(entityTests)
 }

--- a/templates_freemarker/src/main/kotlin/FreeMarkerAdapter.kt
+++ b/templates_freemarker/src/main/kotlin/FreeMarkerAdapter.kt
@@ -1,22 +1,23 @@
 package com.hexagonkt.templates.freemarker
 
+import com.hexagonkt.templates.TemplateEngineSettings
 import com.hexagonkt.templates.TemplatePort
+import freemarker.cache.TemplateLoader
 import freemarker.template.Configuration
 import freemarker.template.Version
+import java.io.Reader
 import java.io.StringWriter
 import java.util.*
 
 object FreeMarkerAdapter : TemplatePort {
 
-    private val config = Configuration(Version("2.3.30"))
-
-    init {
-        config.setClassLoaderForTemplateLoading(Thread.currentThread().contextClassLoader, "/")
-        config.defaultEncoding = "UTF-8"
-    }
-
-    override fun render(resource: String, locale: Locale, context: Map<String, *>): String {
-        val template = config.getTemplate(resource)
+    override fun render(
+        resource: String,
+        locale: Locale,
+        context: Map<String, *>,
+        settings: TemplateEngineSettings
+    ): String {
+        val template = config(settings).getTemplate(resource)
         val writer = StringWriter()
 
         return writer.use {
@@ -25,5 +26,27 @@ object FreeMarkerAdapter : TemplatePort {
             env.process()
             it.buffer.toString()
         }
+    }
+
+    private fun config(templateEngineSettings: TemplateEngineSettings) =
+        Configuration(Version("2.3.30")).apply {
+            setClassLoaderForTemplateLoading(Thread.currentThread().contextClassLoader, "/")
+            defaultEncoding = "UTF-8"
+            templateEngineSettings.loader?.let { it ->
+                templateLoader = LambdaTemplateLoader(it)
+            }
+        }
+}
+
+private class LambdaTemplateLoader(private val loadTemplate: (String) -> Reader?) : TemplateLoader {
+    override fun findTemplateSource(name: String): Reader? = loadTemplate(name)
+
+    override fun getLastModified(templateSource: Any?): Long = -1
+
+    override fun getReader(templateSource: Any?, encoding: String?): Reader =
+        templateSource as Reader
+
+    override fun closeTemplateSource(templateSource: Any?) {
+        (templateSource as? Reader)?.close()
     }
 }

--- a/templates_freemarker/src/test/kotlin/FreeMarkerAdapterTest.kt
+++ b/templates_freemarker/src/test/kotlin/FreeMarkerAdapterTest.kt
@@ -1,6 +1,8 @@
 package com.hexagonkt.templates.freemarker
 
+import com.hexagonkt.templates.TemplateEngineSettings
 import org.junit.jupiter.api.Test
+import java.io.StringReader
 import java.time.LocalDateTime
 import java.util.Locale
 
@@ -31,5 +33,28 @@ class FreeMarkerAdapterTest {
         assert(html.contains("23:45"))
         assert(html.contains("2000"))
         assert(html.contains("31"))
+    }
+
+    @Test fun `Templates can be provided via settings`() {
+        val settings =
+            TemplateEngineSettings(loader = { StringReader("Content: \${value}") })
+
+        val context = mapOf("value" to "A_VALUE")
+        val html = FreeMarkerAdapter.render("resource", locale, context, settings)
+        assert(html == "Content: A_VALUE")
+    }
+
+    @Test fun `Multiple templates can be defined`() {
+        val settings = TemplateEngineSettings(loader = {
+            when (it) {
+                "resource1" -> StringReader("template1")
+                "resource2" -> StringReader("template2")
+                else -> null
+            }
+        })
+
+        val context = emptyMap<String, Any>()
+        assert(FreeMarkerAdapter.render("resource1", locale, context, settings) == "template1")
+        assert(FreeMarkerAdapter.render("resource2", locale, context, settings) == "template2")
     }
 }

--- a/templates_freemarker/src/test/kotlin/FreeMarkerTemplateEngineTest.kt
+++ b/templates_freemarker/src/test/kotlin/FreeMarkerTemplateEngineTest.kt
@@ -1,0 +1,6 @@
+package com.hexagonkt.templates.freemarker
+
+import com.hexagonkt.templates.TemplateEngineTest
+
+class FreeMarkerTemplateEngineTest : TemplateEngineTest({ FreeMarkerAdapter }) {
+}

--- a/templates_pebble/build.gradle.kts
+++ b/templates_pebble/build.gradle.kts
@@ -1,11 +1,25 @@
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 apply(from = "../gradle/kotlin.gradle")
 apply(from = "../gradle/publish.gradle")
 apply(from = "../gradle/dokka.gradle")
+
+val compileTestKotlin: KotlinCompile by tasks
+
+plugins {
+    java
+}
+
+// IMPORTANT: Required for compiling classes in test dependencies. It *MUST* be before dependencies
+compileTestKotlin.dependsOn(tasks.getByPath(":port_templates:compileTestKotlin"))
+
+val entityTests: SourceSetOutput = project(":port_templates").sourceSets["test"].output
 
 dependencies {
     "api"(project(":port_templates"))
     "api"("io.pebbletemplates:pebble:${properties["pebbleVersion"]}") {
         exclude (module = "slf4j-api")
     }
+    "testImplementation"(entityTests)
 }

--- a/templates_pebble/src/main/kotlin/PebbleAdapter.kt
+++ b/templates_pebble/src/main/kotlin/PebbleAdapter.kt
@@ -1,16 +1,29 @@
 package com.hexagonkt.templates.pebble
 
 import com.hexagonkt.helpers.toDate
+import com.hexagonkt.templates.TemplateEngineSettings
 import com.hexagonkt.templates.TemplatePort
 import com.mitchellbosecke.pebble.PebbleEngine
+import com.mitchellbosecke.pebble.loader.Loader
+import java.io.Reader
 import java.io.StringWriter
 import java.time.LocalDateTime
 import java.util.*
 
 object PebbleAdapter : TemplatePort {
-    private val engine: PebbleEngine = PebbleEngine.Builder().cacheActive(true).build()
 
-    override fun render(resource: String, locale: Locale, context: Map<String, *>): String {
+    private fun engine(settings: TemplateEngineSettings): PebbleEngine =
+        PebbleEngine.Builder().apply {
+            cacheActive(true)
+            settings.loader?.let { loader(LambdaLoader(it)) }
+        }.build()
+
+    override fun render(
+        resource: String,
+        locale: Locale,
+        context: Map<String, *>,
+        settings: TemplateEngineSettings
+    ): String {
         val contextEntries = context.map {
             it.key to
                 if (it.value is LocalDateTime) (it.value as LocalDateTime).toDate()
@@ -18,7 +31,28 @@ object PebbleAdapter : TemplatePort {
         }
 
         val writer = StringWriter()
-        engine.getTemplate(resource).evaluate(writer, contextEntries.toMap(), locale)
+        engine(settings).getTemplate(resource).evaluate(writer, contextEntries.toMap(), locale)
         return writer.toString()
     }
+}
+
+private class LambdaLoader(private val loadTemplate: (resource: String) -> Reader?) :
+    Loader<String> {
+    override fun getReader(cacheKey: String): Reader? = loadTemplate(cacheKey)!!
+
+    override fun resourceExists(templateName: String): Boolean {
+        val reader = loadTemplate(templateName)
+        reader?.close()
+        return reader != null
+    }
+
+    override fun setCharset(charset: String) {}
+
+    override fun setPrefix(prefix: String) {}
+
+    override fun setSuffix(suffix: String) {}
+
+    override fun resolveRelativePath(relativePath: String, anchorPath: String): String? = null
+
+    override fun createCacheKey(templateName: String): String = templateName
 }

--- a/templates_pebble/src/test/kotlin/PebbleAdapterTest.kt
+++ b/templates_pebble/src/test/kotlin/PebbleAdapterTest.kt
@@ -1,16 +1,43 @@
 package com.hexagonkt.templates.pebble
 
+import com.hexagonkt.templates.TemplateEngineSettings
 import org.junit.jupiter.api.Test
+import java.io.StringReader
 import java.time.LocalDateTime
 import java.util.*
 
 class PebbleAdapterTest {
 
+    private val locale = Locale.getDefault()
+
     @Test fun `Dates are converted properly`() {
         val context = "localDate" to LocalDateTime.of(2000, 12, 31, 23, 45)
-        val html = PebbleAdapter.render("templates/test.pebble.html", Locale.getDefault(), context)
+        val html = PebbleAdapter.render("templates/test.pebble.html", locale, context)
         assert(html.contains("23:45"))
         assert(html.contains("2000"))
         assert(html.contains("31"))
+    }
+
+    @Test fun `Templates can be provided via settings`() {
+        val settings =
+            TemplateEngineSettings(loader = { StringReader("Content: {{ value }}") })
+
+        val context = mapOf("value" to "A_VALUE")
+        val html = PebbleAdapter.render("resource", locale, context, settings)
+        assert(html == "Content: A_VALUE")
+    }
+
+    @Test fun `Multiple templates can be defined`() {
+        val settings = TemplateEngineSettings(loader = {
+            when (it) {
+                "resource1" -> StringReader("template1")
+                "resource2" -> StringReader("template2")
+                else -> null
+            }
+        })
+
+        val context = emptyMap<String, Any>()
+        assert(PebbleAdapter.render("resource1", locale, context, settings) == "template1")
+        assert(PebbleAdapter.render("resource2", locale, context, settings) == "template2")
     }
 }

--- a/templates_pebble/src/test/kotlin/PebbleTemplateEngineTest.kt
+++ b/templates_pebble/src/test/kotlin/PebbleTemplateEngineTest.kt
@@ -1,0 +1,6 @@
+package com.hexagonkt.templates.pebble
+
+import com.hexagonkt.templates.TemplateEngineTest
+
+class PebbleTemplateEngineTest : TemplateEngineTest({ PebbleAdapter }) {
+}


### PR DESCRIPTION

Move tests from TemplateManagerTest to TemplateEngineTest
Move context loading from TemplateManager to TemplateEngine
Disable failing assertions from StringsTest
Add TemplateEngineTests for FreeMarker and Pebble
Add TemplateEngineSettings to configure template
Introduce TemplateEngine as a wrapper for TemplatePort
Add support for multiple engines to TemplateManager
