### PR TITLE
fix: reset timezone mongodb tests

### DIFF
--- a/store_mongodb/src/test/kotlin/MongoDbStoreCompanyTest.kt
+++ b/store_mongodb/src/test/kotlin/MongoDbStoreCompanyTest.kt
@@ -6,6 +6,7 @@ import com.hexagonkt.store.IndexOrder.ASCENDING
 import com.hexagonkt.store.IndexOrder.DESCENDING
 import com.hexagonkt.store.Store
 import org.bson.types.ObjectId
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -13,6 +14,7 @@ import java.net.URL
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.util.*
 
 class MongoDbStoreCompanyTest {
 
@@ -43,6 +45,14 @@ class MongoDbStoreCompanyTest {
 
     private fun changeObject(obj: Company) =
         obj.copy(web = URL("http://change.example.org"))
+
+    companion object {
+        @BeforeAll
+        @JvmStatic
+        fun resetTimeZone() {
+            TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        }
+    }
 
     @BeforeEach fun dropCollection() {
         store.drop()


### PR DESCRIPTION
timezone now being reset to utc for mongodb tests
otherwise some test cases will result in asserted
date being off by one day.


---

For the Pull Request to be accepted please check:

- [x] The PR has a meaningful title.
- [x] If the PR refers to an issue, it should be referenced with the Github format (*#ID*).
- [x] The PR is done to the `develop` branch.
- [x] The code pass all PR checks.
- [x] All public members are documented using [Dokka](https://github.com/Kotlin/dokka).
- [x] The code follow the coding conventions stated at the [contributing.md](/contributing.md) file.
