### PR TITLE
Add support for authentication validation in mock server

### DIFF
--- a/port_http_server/README.md
+++ b/port_http_server/README.md
@@ -352,6 +352,7 @@ The mock server takes all its data from the spec and the request and response of
 determined by the routes' examples and schemas.
 During handling of a request, the mock server validates the request parameters against those
 specified in the spec file and returns an appropriate response from the [provided examples](#providing-examples).
+If any authentication requirements are specified, they are validated as well.
 #### How to Use
 
 To create the mock server object:
@@ -379,8 +380,16 @@ The file provided should be a syntactically valid OpenAPI spec file. If it is no
 raised at initialization time.
 
 For each path in the spec file, descriptions for 200 and 400 (in case parameter verification fails)
-status codes must be provided. In addition, for each status code, at least one example must be
+status codes must be provided. If the path contains authentication requirements, a 401 status code
+description must also be provided. In addition, for each status code, at least one example must be
 provided. Note that, at present, only the `application/json` media type is supported.
+
+#### Supported Authentication Methods
+
+Currently, the following Authentication methods/mechanisms are supported:
+
+* API Key authentication (key may be present in the headers, query parameters or cookies)
+* HTTP Authentication (Basic or Bearer authentication)
 
 #### Providing Examples
 

--- a/port_http_server/src/test/resources/openapi_test.json
+++ b/port_http_server/src/test/resources/openapi_test.json
@@ -5,6 +5,43 @@
     "description": "This is a test OpenAPI spec for the Hexagon Mock Server project.",
     "version": "1.0.0"
   },
+  "components": {
+    "securitySchemes": {
+      "basic": {
+        "type": "http",
+        "scheme": "basic"
+      },
+      "bearer": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      },
+      "unknown": {
+        "type": "http",
+        "scheme": "unknown"
+      },
+      "api_key_query": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "query"
+      },
+      "api_key_header": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      },
+      "api_key_cookie": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "cookie"
+      },
+      "api_key_unknown": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "unknown"
+      }
+    }
+  },
   "paths": {
     "/ping" : {
       "get": {
@@ -403,6 +440,301 @@
             "content": {
               "application/json": {
                 "example": "invalid or missing request body"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check-optional-auth": {
+      "get": {
+        "summary": "An endpoint with optional authentication",
+        "description": "An endpoint with optional authentication",
+        "security": [
+          {
+            "basic": [ ]
+          },
+          { }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "example": "success"
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid authorization credentials",
+            "content": {
+              "application/json": {
+                "example": "Invalid authorization credentials"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check-basic-auth": {
+      "get": {
+        "summary": "An endpoint that requires basic (username/password) authentication",
+        "description": "An endpoint that requires basic (username/password) authentication",
+        "security": [
+          {
+            "basic": [ ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "example": "success"
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid authorization credentials",
+            "content": {
+              "application/json": {
+                "example": "Invalid authorization credentials"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check-bearer-auth": {
+      "get": {
+        "summary": "An endpoint that requires bearer JWT authentication",
+        "description": "An endpoint that requires bearer JWT authentication",
+        "security": [
+          {
+            "bearer": [ ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "example": "success"
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid authorization credentials",
+            "content": {
+              "application/json": {
+                "example": "Invalid authorization credentials"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check-unknown-auth": {
+      "get": {
+        "summary": "An endpoint that requires authentication of an unknown scheme",
+        "description": "An endpoint that requires authentication of an unknown scheme",
+        "security": [
+          {
+            "unknown": [ ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "example": "success"
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid authorization credentials",
+            "content": {
+              "application/json": {
+                "example": "Invalid authorization credentials"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check-query-api-auth": {
+      "get": {
+        "summary": "An endpoint that requires authentication with an API key present in the query params",
+        "description": "An endpoint that requires authentication with an API key present in the query params",
+        "security": [
+          {
+            "api_key_query": [ ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "example": "success"
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid authorization credentials",
+            "content": {
+              "application/json": {
+                "example": "Invalid authorization credentials"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check-header-api-auth": {
+      "get": {
+        "summary": "An endpoint that requires authentication with an API key present in the header",
+        "description": "An endpoint that requires authentication with an API key present in the header",
+        "security": [
+          {
+            "api_key_header": [ ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "example": "success"
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid authorization credentials",
+            "content": {
+              "application/json": {
+                "example": "Invalid authorization credentials"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check-cookie-api-auth": {
+      "get": {
+        "summary": "An endpoint that requires authentication with an API key present in the cookies",
+        "description": "An endpoint that requires authentication with an API key present in the cookies",
+        "security": [
+          {
+            "api_key_cookie": [ ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "example": "success"
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid authorization credentials",
+            "content": {
+              "application/json": {
+                "example": "Invalid authorization credentials"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check-unknown-api-auth": {
+      "get": {
+        "summary": "An endpoint that requires authentication with an API key present in an unknown location",
+        "description": "An endpoint that requires authentication with an API key present in an unknown location",
+        "security": [
+          {
+            "api_key_unknown": [ ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "example": "success"
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid authorization credentials",
+            "content": {
+              "application/json": {
+                "example": "Invalid authorization credentials"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check-multiple-mechanisms": {
+      "get": {
+        "summary": "An endpoint that contains multiple security mechanisms",
+        "description": "An endpoint that contains multiple security mechanisms, any one of which need to be satisfied",
+        "security": [
+          {
+            "api_key_cookie": [ ]
+          },
+          {
+            "basic": [ ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "example": "success"
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid authorization credentials",
+            "content": {
+              "application/json": {
+                "example": "Invalid authorization credentials"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/check-multiple-schemes": {
+      "get": {
+        "summary": "An endpoint that contains multiple security schemes",
+        "description": "An endpoint that contains multiple security schemes, all of which need to be satisfied",
+        "security": [
+          {
+            "api_key_cookie": [ ],
+            "basic": [ ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "example": "success"
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid authorization credentials",
+            "content": {
+              "application/json": {
+                "example": "Invalid authorization credentials"
               }
             }
           }


### PR DESCRIPTION
This PR adds support for authentication to the OpenAPI Mock Server. Currently it supports the following authentication methods:

- API key (present in the header, query parameters or cookies)
- Basic HTTP authentication
- Bearer HTTP authentication