### PR TITLE
Fix: upgrade mkdocs, handle hero deprecation #339

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ version: '3'
 services:
 
   site:
-    image: squidfunk/mkdocs-material:5.5.14
+    image: squidfunk/mkdocs-material:6.1.7
     volumes:
       - ./hexagon_site:/docs
     ports:

--- a/hexagon_site/assets/css/mkdocs.css
+++ b/hexagon_site/assets/css/mkdocs.css
@@ -96,6 +96,7 @@ div.md-hero + .md-tabs__item {
 }
 
 .md-hero {
+  color: white;
   font-size: .95rem;
 }
 

--- a/hexagon_site/mkdocs.yml
+++ b/hexagon_site/mkdocs.yml
@@ -110,8 +110,8 @@ theme:
     repo: fontawesome/brands/github-alt
 
   features:
-    - tabs
-    - instant
+    - navigation.tabs
+    - nagivation.instant
 
   palette:
     primary: indigo

--- a/hexagon_site/mkdocs/main.html
+++ b/hexagon_site/mkdocs/main.html
@@ -50,6 +50,41 @@ if ('serviceWorker' in navigator)
 -->
 {% endblock %}
 
+{% block hero %}
+  {% set class = "md-hero" %}
+  {% if "navigation.tabs" not in config.theme.features %}
+  {% set class = "md-hero md-hero--expand" %}
+  {% endif %}
+  <div class="{{ class }}">
+    <div class="md-hero__inner md-grid">
+      <p align="center">
+        <img alt="Hexagon" src="tile-small.png" />
+        <br />
+        <a href="https://github.com/hexagonkt/hexagon/actions">
+          <img
+            alt="GitHub Actions"
+            src="https://github.com/hexagonkt/hexagon/workflows/Release/badge.svg" />
+        </a>
+        <a href="/jacoco">
+          <img src="/img/coverage.svg" alt="Coverage" />
+        </a>
+        <a href="https://search.maven.org/search?q=g:com.hexagonkt">
+          <img src="/img/download.svg" alt="Maven Central Repository" />
+        </a>
+      </p>
+
+      <h1 align="center">The atoms of your platform</h1>
+
+      <p align="center" id="description">
+        Hexagon is a microservices
+        <a href="https://stackoverflow.com/a/3057818/973418">toolkit</a> written in
+        <a href="http://kotlinlang.org">Kotlin</a>. Its purpose is to ease the building of server
+        applications (Web applications, APIs, or queue consumers) that run inside a cloud platform.
+      </p>
+    </div>
+  </div>
+{% endblock %}
+
 {% block content %}
   {% if config.repo_url and page.meta.edit_url %}
     <a href="{{ config.repo_url + page.meta.edit_url }}" title="{{ lang.t('edit.link.title') }}" class="md-content__button md-icon">
@@ -66,11 +101,6 @@ if ('serviceWorker' in navigator)
     <h1>{{ page.title | default(config.site_name, true)}}</h1>
   {% endif %}
   {{ page.content }}
-  {% block source %}
-    {% if page and page.meta and page.meta.source %}
-      {% include "partials/source-link.html" %}
-    {% endif %}
-  {% endblock %}
 {% endblock %}
 {% block disqus %}
   {% include "partials/integrations/disqus.html" %}

--- a/hexagon_site/mkdocs/partials/hero.html
+++ b/hexagon_site/mkdocs/partials/hero.html
@@ -1,9 +1,0 @@
-{% set class = "md-hero" %}
-{% if "tabs" not in config.theme.features %}
-  {% set class = "md-hero md-hero--expand" %}
-{% endif %}
-<div class="{{ class }}">
-  <div class="md-hero__inner md-grid">
-    {{ page.meta.hero }}
-  </div>
-</div>

--- a/hexagon_site/pages/index.md
+++ b/hexagon_site/pages/index.md
@@ -1,31 +1,3 @@
----
-hero: |
-  <p align="center">
-    <img alt="Hexagon" src="tile-small.png" />
-    <br />
-    <a href="https://github.com/hexagonkt/hexagon/actions">
-      <img
-        alt="GitHub Actions"
-        src="https://github.com/hexagonkt/hexagon/workflows/Release/badge.svg" />
-    </a>
-    <a href="/jacoco">
-      <img src="/img/coverage.svg" alt="Coverage" />
-    </a>
-    <a href="https://search.maven.org/search?q=g:com.hexagonkt">
-      <img src="/img/download.svg" alt="Maven Central Repository" />
-    </a>
-  </p>
-
-  <h1 align="center">The atoms of your platform</h1>
-
-  <p align="center" id="description">
-    Hexagon is a microservices
-    <a href="https://stackoverflow.com/a/3057818/973418">toolkit</a> written in
-    <a href="http://kotlinlang.org">Kotlin</a>. Its purpose is to ease the building of server
-    applications (Web applications, APIs, or queue consumers) that run inside a cloud platform.
-  </p>
----
-
 The Hexagon Toolkit provides several libraries to build server applications. These libraries provide
 single standalone features[^1] and are referred to as ["Ports"][Ports and Adapters Architecture].
 


### PR DESCRIPTION
This PR is for upgrading mkdocs material from version 5.x to version 6.x (6.1.7 latest stable release). There was a deprecation of the hero content (https://squidfunk.github.io/mkdocs-material/deprecations/#hero) within mkdocs but an override still exists which was implemented to present the hero content as it is in production today.

---

For the Pull Request to be accepted please check:

- [x] The PR has a meaningful title.
- [x] If the PR refers to an issue, it should be referenced with the Github format (*#ID*).
- [x] The PR is done to the `develop` branch.
- [x] The code pass all PR checks.
- [x] All public members are documented using [Dokka](https://github.com/Kotlin/dokka).
- [x] The code follow the coding conventions stated at the [contributing.md](/contributing.md) file.
