### PR TITLE
Add required dependencies to OpenAPI Mock Server docs

### DIFF
--- a/port_http_server/README.md
+++ b/port_http_server/README.md
@@ -355,6 +355,12 @@ specified in the spec file and returns an appropriate response from the [provide
 If any authentication requirements are specified, they are validated as well.
 #### How to Use
 
+First, add the required dependencies:
+```kotlin
+implementation("com.hexagonkt:port_http_server:$hexagonVersion:test")
+implementation("io.swagger.parser.v3:swagger-parser:$swaggerParserVersion")
+```
+
 To create the mock server object:
 ```kotlin
 val mockServer = MockServer("https://petstore3.swagger.io/api/v3/openapi.json")


### PR DESCRIPTION
The list of required dependencies was missing in the docs for setting up and using the OpenAPI Mock Server. This PR is to fix the missing docs.