### PR TITLE
Add assertions to check imported resources on store

### DIFF
--- a/store_mongodb/src/test/kotlin/CompanyTest.kt
+++ b/store_mongodb/src/test/kotlin/CompanyTest.kt
@@ -52,7 +52,7 @@ internal class CompanyTest : StoreTest<Company, String>() {
         )
     )
 
-    override fun createTestEntities(): List<Company> = listOf (company, company1)
+    override fun createTestEntities(): List<Company> = listOf(company, company1)
 
     private val mongodbUrl by lazy {
         SettingsManager.instance<Map<*, *>>()["mongodbUrl"] as? String?


### PR DESCRIPTION
This PR addresses, the TODO task on the CompanyTest at `store_mongodb` for asserting the resources that are imported on the store from an  URL and a file

- The issue is listed #369 here
- This PR is done on a development branch